### PR TITLE
ci: Update the deployment workflow

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -3,7 +3,7 @@ name: Continuous Deployment
 on:
   push:
     branches:
-      - main
+      - master
 
 jobs:
   release-plz:


### PR DESCRIPTION
To point to the master branch instead of the main branch