### PR TITLE
refactor: Renaming the `get_` methods

### DIFF
--- a/benches/model.rs
+++ b/benches/model.rs
@@ -34,22 +34,22 @@ criterion_main!(benches);
 
 pub fn motion_model_get_children(c: &mut Criterion) {
     let model = create_model_and_fill();
-    let wheel_ids = model.get_wheels().unwrap();
+    let wheel_ids = model.wheels().unwrap();
 
     c.bench_function("MotionModel::get_children", |b| {
-        b.iter(|| model.get_children(black_box(wheel_ids.first().unwrap())));
+        b.iter(|| model.children_of(black_box(wheel_ids.first().unwrap())));
     });
 }
 
 pub fn motion_model_get_homogeneous_transform_between_frames(c: &mut Criterion) {
     let model = create_model_and_fill();
-    let wheel_ids = model.get_wheels().unwrap();
+    let wheel_ids = model.wheels().unwrap();
 
     c.bench_function(
         "MotionModel::get_homogeneous_transform_between_frames",
         |b| {
             b.iter(|| {
-                model.get_homogeneous_transform_between_frames(
+                model.homogeneous_transform_between_frames(
                     black_box(wheel_ids.first().unwrap()),
                     black_box(wheel_ids.get(1).unwrap()),
                 )
@@ -60,12 +60,12 @@ pub fn motion_model_get_homogeneous_transform_between_frames(c: &mut Criterion) 
 
 pub fn motion_model_get_homogeneous_transform_to_ancestor(c: &mut Criterion) {
     let model = create_model_and_fill();
-    let wheel_ids = model.get_wheels().unwrap();
-    let body_id = model.get_body().unwrap();
+    let wheel_ids = model.wheels().unwrap();
+    let body_id = model.body().unwrap();
 
     c.bench_function("MotionModel::get_homogeneous_transform_to_ancestor", |b| {
         b.iter(|| {
-            model.get_homogeneous_transform_to_ancestor(
+            model.homogeneous_transform_to_ancestor(
                 black_box(wheel_ids.first().unwrap()),
                 black_box(body_id),
             )
@@ -75,34 +75,34 @@ pub fn motion_model_get_homogeneous_transform_to_ancestor(c: &mut Criterion) {
 
 pub fn motion_model_get_homogeneous_transform_to_body(c: &mut Criterion) {
     let model = create_model_and_fill();
-    let wheel_ids = model.get_wheels().unwrap();
+    let wheel_ids = model.wheels().unwrap();
 
     c.bench_function("MotionModel::get_homogeneous_transform_to_body", |b| {
-        b.iter(|| model.get_homogeneous_transform_to_body(black_box(wheel_ids.first().unwrap())));
+        b.iter(|| model.homogeneous_transform_to_body(black_box(wheel_ids.first().unwrap())));
     });
 }
 
 pub fn motion_model_get_homogeneous_transform_to_parent(c: &mut Criterion) {
     let model = create_model_and_fill();
-    let wheel_ids = model.get_wheels().unwrap();
+    let wheel_ids = model.wheels().unwrap();
 
     c.bench_function("MotionModel::get_homogeneous_transform_to_parent", |b| {
-        b.iter(|| model.get_homogeneous_transform_to_parent(black_box(wheel_ids.first().unwrap())));
+        b.iter(|| model.homogeneous_transform_to_parent(black_box(wheel_ids.first().unwrap())));
     });
 }
 
 pub fn motion_model_get_steering_frame_for_wheel(c: &mut Criterion) {
     let model = create_model_and_fill();
-    let wheel_ids = model.get_wheels().unwrap();
+    let wheel_ids = model.wheels().unwrap();
 
     c.bench_function("MotionModel::get_steering_frame_for_wheel", |b| {
-        b.iter(|| model.get_steering_frame_for_wheel(black_box(wheel_ids.first().unwrap())));
+        b.iter(|| model.steering_frame_for_wheel(black_box(wheel_ids.first().unwrap())));
     });
 }
 
 pub fn motion_model_is_ancestor(c: &mut Criterion) {
     let model = create_model_and_fill();
-    let wheel_ids = model.get_wheels().unwrap();
+    let wheel_ids = model.wheels().unwrap();
 
     c.bench_function("MotionModel::is_ancestor", |b| {
         b.iter(|| {
@@ -223,17 +223,17 @@ struct MockHardwareActuator {
 }
 
 impl HardwareActuator for MockHardwareActuator {
-    fn get_actuator_motion_type(&self) -> NumberSpaceType {
+    fn actuator_motion_type(&self) -> NumberSpaceType {
         NumberSpaceType::LinearUnlimited
     }
 
-    fn get_current_state_receiver(
+    fn current_state_receiver(
         &self,
     ) -> Result<Receiver<(JointState, ActuatorAvailableRatesOfChange)>, Error> {
         Ok(self.receiver.clone())
     }
 
-    fn get_command_sender(&self) -> Result<Sender<JointState>, Error> {
+    fn command_sender(&self) -> Result<Sender<JointState>, Error> {
         Ok(self.command_sender.clone())
     }
 
@@ -242,7 +242,7 @@ impl HardwareActuator for MockHardwareActuator {
         self.update_sender = Some(sender);
     }
 
-    fn get_actuator_range(&self) -> JointStateRange {
+    fn actuator_range(&self) -> JointStateRange {
         todo!()
     }
 }

--- a/src/hardware/actuator_interface.rs
+++ b/src/hardware/actuator_interface.rs
@@ -32,6 +32,7 @@ mod actuator_interface_tests;
 /// The maximum value stored is assumed to be the greatest value for motion
 /// in positive direction, while the minimum value is assumed to be the greatest
 /// value for motion in the negative direction.
+#[derive(Clone, Copy, Debug)]
 pub struct ActuatorAvailableRatesOfChange {
     /// The current minimum velocity
     minimum_velocity: f64,
@@ -54,63 +55,33 @@ pub struct ActuatorAvailableRatesOfChange {
 
 impl ActuatorAvailableRatesOfChange {
     /// Returns the current maximum acceleration.
-    pub fn get_maximum_acceleration(&self) -> f64 {
+    pub fn maximum_acceleration(&self) -> f64 {
         self.maximum_acceleration
     }
 
     /// Returns the current maximum jerk.
-    pub fn get_maximum_jerk(&self) -> f64 {
+    pub fn maximum_jerk(&self) -> f64 {
         self.maximum_jerk
     }
 
     /// Returns the current maximum velocity.
-    pub fn get_maximum_velocity(&self) -> f64 {
+    pub fn maximum_velocity(&self) -> f64 {
         self.maximum_velocity
     }
 
     /// Returns the current minimum acceleration.
-    pub fn get_minimum_acceleration(&self) -> f64 {
+    pub fn minimum_acceleration(&self) -> f64 {
         self.minimum_acceleration
     }
 
     /// Returns the current minimum jerk.
-    pub fn get_minimum_jerk(&self) -> f64 {
+    pub fn minimum_jerk(&self) -> f64 {
         self.minimum_jerk
     }
 
     /// Returns the current minimum velocity.
-    pub fn get_minimum_velocity(&self) -> f64 {
+    pub fn minimum_velocity(&self) -> f64 {
         self.minimum_velocity
-    }
-
-    /// Sets the current maximum acceleration.
-    pub fn set_maximum_acceleration(&mut self, maximum_acceleration: f64) {
-        self.maximum_acceleration = maximum_acceleration;
-    }
-
-    /// Sets the current maximum jerk.
-    pub fn set_maximum_jerk(&mut self, maximum_jerk: f64) {
-        self.maximum_jerk = maximum_jerk;
-    }
-
-    /// Sets the current maximum velocity.
-    pub fn set_maximum_velocity(&mut self, maximum_velocity: f64) {
-        self.maximum_velocity = maximum_velocity;
-    }
-
-    /// Sets the current minimum acceleration.
-    pub fn set_minimum_acceleration(&mut self, minimum_acceleration: f64) {
-        self.minimum_acceleration = minimum_acceleration;
-    }
-
-    /// Sets the current minimum jerk.
-    pub fn set_minimum_jerk(&mut self, minimum_jerk: f64) {
-        self.minimum_jerk = minimum_jerk;
-    }
-
-    /// Sets the current minimum velocity.
-    pub fn set_minimum_velocity(&mut self, minimum_velocity: f64) {
-        self.minimum_velocity = minimum_velocity;
     }
 
     /// Creates a new instance of [ActuatorAvailableRatesOfChange] with the given values
@@ -132,14 +103,14 @@ impl ActuatorAvailableRatesOfChange {
     ///
     /// let result = ActuatorAvailableRatesOfChange::new(-10.0, 10.0, -5.0, 5.0, -20.0, 20.0);
     ///
-    /// assert_eq!(result.get_minimum_velocity(), -10.0);
-    /// assert_eq!(result.get_maximum_velocity(), 10.0);
+    /// assert_eq!(result.minimum_velocity(), -10.0);
+    /// assert_eq!(result.maximum_velocity(), 10.0);
     ///
-    /// assert_eq!(result.get_minimum_acceleration(), -5.0);
-    /// assert_eq!(result.get_maximum_acceleration(), 5.0);
+    /// assert_eq!(result.minimum_acceleration(), -5.0);
+    /// assert_eq!(result.maximum_acceleration(), 5.0);
     ///
-    /// assert_eq!(result.get_minimum_jerk(), -20.0);
-    /// assert_eq!(result.get_maximum_jerk(), 20.0);
+    /// assert_eq!(result.minimum_jerk(), -20.0);
+    /// assert_eq!(result.maximum_jerk(), 20.0);
     /// ```
     pub fn new(
         minimum_velocity: f64,
@@ -163,18 +134,18 @@ impl ActuatorAvailableRatesOfChange {
 /// Defines the interface for hardware that moves a robot joint element.
 pub trait HardwareActuator {
     /// Returns the [NumberSpaceType] that is used to describe the motion of the actuator.
-    fn get_actuator_motion_type(&self) -> NumberSpaceType;
+    fn actuator_motion_type(&self) -> NumberSpaceType;
 
     /// Returns the minimum and maximum states for the actuator.
-    fn get_actuator_range(&self) -> JointStateRange;
+    fn actuator_range(&self) -> JointStateRange;
 
     /// Returns the [Sender] that can be used to send command values to the
     /// actuator implementation.
-    fn get_command_sender(&self) -> Result<Sender<JointState>, Error>;
+    fn command_sender(&self) -> Result<Sender<JointState>, Error>;
 
     /// Returns the [Receiver] that is used to receive the current [JointState]
     /// and the currently available minimum and maximum rate of change.
-    fn get_current_state_receiver(
+    fn current_state_receiver(
         &self,
     ) -> Result<Receiver<(JointState, ActuatorAvailableRatesOfChange)>, Error>;
 

--- a/src/hardware/actuator_interface_tests.rs
+++ b/src/hardware/actuator_interface_tests.rs
@@ -4,45 +4,22 @@ use super::*;
 fn test_new_instance() {
     let rates_of_change = ActuatorAvailableRatesOfChange::new(1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
 
-    assert_eq!(rates_of_change.get_minimum_velocity(), 1.0);
-    assert_eq!(rates_of_change.get_maximum_velocity(), 2.0);
-    assert_eq!(rates_of_change.get_minimum_acceleration(), 3.0);
-    assert_eq!(rates_of_change.get_maximum_acceleration(), 4.0);
-    assert_eq!(rates_of_change.get_minimum_jerk(), 5.0);
-    assert_eq!(rates_of_change.get_maximum_jerk(), 6.0);
+    assert_eq!(rates_of_change.minimum_velocity(), 1.0);
+    assert_eq!(rates_of_change.maximum_velocity(), 2.0);
+    assert_eq!(rates_of_change.minimum_acceleration(), 3.0);
+    assert_eq!(rates_of_change.maximum_acceleration(), 4.0);
+    assert_eq!(rates_of_change.minimum_jerk(), 5.0);
+    assert_eq!(rates_of_change.maximum_jerk(), 6.0);
 }
 
 #[test]
 fn test_getters() {
     let rates_of_change = ActuatorAvailableRatesOfChange::new(1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
 
-    assert_eq!(rates_of_change.get_minimum_velocity(), 1.0);
-    assert_eq!(rates_of_change.get_maximum_velocity(), 2.0);
-    assert_eq!(rates_of_change.get_minimum_acceleration(), 3.0);
-    assert_eq!(rates_of_change.get_maximum_acceleration(), 4.0);
-    assert_eq!(rates_of_change.get_minimum_jerk(), 5.0);
-    assert_eq!(rates_of_change.get_maximum_jerk(), 6.0);
-}
-
-#[test]
-fn test_setters() {
-    let mut rates_of_change = ActuatorAvailableRatesOfChange::new(1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
-
-    rates_of_change.set_minimum_velocity(10.0);
-    assert_eq!(rates_of_change.get_minimum_velocity(), 10.0);
-
-    rates_of_change.set_maximum_velocity(20.0);
-    assert_eq!(rates_of_change.get_maximum_velocity(), 20.0);
-
-    rates_of_change.set_minimum_acceleration(30.0);
-    assert_eq!(rates_of_change.get_minimum_acceleration(), 30.0);
-
-    rates_of_change.set_maximum_acceleration(40.0);
-    assert_eq!(rates_of_change.get_maximum_acceleration(), 40.0);
-
-    rates_of_change.set_minimum_jerk(50.0);
-    assert_eq!(rates_of_change.get_minimum_jerk(), 50.0);
-
-    rates_of_change.set_maximum_jerk(60.0);
-    assert_eq!(rates_of_change.get_maximum_jerk(), 60.0);
+    assert_eq!(rates_of_change.minimum_velocity(), 1.0);
+    assert_eq!(rates_of_change.maximum_velocity(), 2.0);
+    assert_eq!(rates_of_change.minimum_acceleration(), 3.0);
+    assert_eq!(rates_of_change.maximum_acceleration(), 4.0);
+    assert_eq!(rates_of_change.minimum_jerk(), 5.0);
+    assert_eq!(rates_of_change.maximum_jerk(), 6.0);
 }

--- a/src/hardware/joint_state.rs
+++ b/src/hardware/joint_state.rs
@@ -15,7 +15,7 @@ mod joint_state_tests;
 /// All values are assumed to be in the range of the [minimum, maximum] value
 /// for the joint. These minimum and maximum values are specified by the
 /// [JointStateRange].
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JointState {
     /// The position of the joint.
     position: f64,
@@ -32,22 +32,22 @@ pub struct JointState {
 
 impl JointState {
     /// Returns the current acceleration of the joint.
-    pub fn get_acceleration(&self) -> &Option<f64> {
+    pub fn acceleration(&self) -> &Option<f64> {
         &self.acceleration
     }
 
     /// Returns the current jerk of the joint.
-    pub fn get_jerk(&self) -> &Option<f64> {
+    pub fn jerk(&self) -> &Option<f64> {
         &self.jerk
     }
 
     /// Returns the current position of the joint
-    pub fn get_position(&self) -> f64 {
+    pub fn position(&self) -> f64 {
         self.position
     }
 
     /// Returns the current velocity of the joint.
-    pub fn get_velocity(&self) -> &Option<f64> {
+    pub fn velocity(&self) -> &Option<f64> {
         &self.velocity
     }
 
@@ -76,7 +76,7 @@ impl JointState {
 
 /// Stores the maximum and minimum values for the [JointState] of an
 /// Sensor or Actuator.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct JointStateRange {
     /// The minimum values of the actuator state.
     minimum: JointState,
@@ -87,43 +87,43 @@ pub struct JointStateRange {
 
 impl JointStateRange {
     /// Gets the maximum acceleration for the joint.
-    pub fn get_maximum_acceleration(&self) -> &Option<f64> {
-        self.maximum.get_acceleration()
+    pub fn maximum_acceleration(&self) -> &Option<f64> {
+        self.maximum.acceleration()
     }
 
     /// Gets the maximum jerk for the joint.
-    pub fn get_maximum_jerk(&self) -> &Option<f64> {
-        self.maximum.get_jerk()
+    pub fn maximum_jerk(&self) -> &Option<f64> {
+        self.maximum.jerk()
     }
 
     /// Gets the maximum position for the joint.
-    pub fn get_maximum_position(&self) -> f64 {
-        self.maximum.get_position()
+    pub fn maximum_position(&self) -> f64 {
+        self.maximum.position()
     }
 
     /// Gets the maximum velocity for the joint.
-    pub fn get_maximum_velocity(&self) -> &Option<f64> {
-        self.maximum.get_velocity()
+    pub fn maximum_velocity(&self) -> &Option<f64> {
+        self.maximum.velocity()
     }
 
     /// Gets the minimum acceleration for the joint.
-    pub fn get_minimum_acceleration(&self) -> &Option<f64> {
-        self.minimum.get_acceleration()
+    pub fn minimum_acceleration(&self) -> &Option<f64> {
+        self.minimum.acceleration()
     }
 
     /// Gets the minimum jerk for the joint.
-    pub fn get_minimum_jerk(&self) -> &Option<f64> {
-        self.minimum.get_jerk()
+    pub fn minimum_jerk(&self) -> &Option<f64> {
+        self.minimum.jerk()
     }
 
     /// Gets the minimum position for the joint.
-    pub fn get_minimum_position(&self) -> f64 {
-        self.minimum.get_position()
+    pub fn minimum_position(&self) -> f64 {
+        self.minimum.position()
     }
 
     /// Gets the minimum velocity for the joint.
-    pub fn get_minimum_velocity(&self) -> &Option<f64> {
-        self.minimum.get_velocity()
+    pub fn minimum_velocity(&self) -> &Option<f64> {
+        self.minimum.velocity()
     }
 
     /// Creates a new [JointStateRange] with the given minimum and maximum

--- a/src/hardware/joint_state_tests.rs
+++ b/src/hardware/joint_state_tests.rs
@@ -9,10 +9,10 @@ fn test_new_joint_state() {
 
     let joint_state = JointState::new(position, velocity, acceleration, jerk);
 
-    assert_eq!(joint_state.get_position(), position);
-    assert_eq!(*joint_state.get_velocity(), velocity);
-    assert_eq!(*joint_state.get_acceleration(), acceleration);
-    assert_eq!(*joint_state.get_jerk(), jerk);
+    assert_eq!(joint_state.position(), position);
+    assert_eq!(*joint_state.velocity(), velocity);
+    assert_eq!(*joint_state.acceleration(), acceleration);
+    assert_eq!(*joint_state.jerk(), jerk);
 }
 
 #[test]
@@ -22,22 +22,22 @@ fn test_joint_state_range_new() {
 
     let range = JointStateRange::new(min_state, max_state);
 
-    assert_eq!(range.get_minimum_position(), -100.0);
-    assert_eq!(range.get_maximum_position(), 100.0);
-    assert_eq!(*range.get_minimum_velocity(), Some(-50.0));
-    assert_eq!(*range.get_maximum_velocity(), Some(50.0));
-    assert_eq!(*range.get_minimum_acceleration(), Some(-20.0));
-    assert_eq!(*range.get_maximum_acceleration(), Some(20.0));
-    assert_eq!(*range.get_minimum_jerk(), Some(-10.0));
-    assert_eq!(*range.get_maximum_jerk(), Some(10.0));
+    assert_eq!(range.minimum_position(), -100.0);
+    assert_eq!(range.maximum_position(), 100.0);
+    assert_eq!(*range.minimum_velocity(), Some(-50.0));
+    assert_eq!(*range.maximum_velocity(), Some(50.0));
+    assert_eq!(*range.minimum_acceleration(), Some(-20.0));
+    assert_eq!(*range.maximum_acceleration(), Some(20.0));
+    assert_eq!(*range.minimum_jerk(), Some(-10.0));
+    assert_eq!(*range.maximum_jerk(), Some(10.0));
 }
 
 #[test]
 fn test_joint_state_defaults() {
     let joint_state = JointState::new(0.0, None, None, None);
 
-    assert_eq!(joint_state.get_position(), 0.0);
-    assert!(joint_state.get_velocity().is_none());
-    assert!(joint_state.get_acceleration().is_none());
-    assert!(joint_state.get_jerk().is_none());
+    assert_eq!(joint_state.position(), 0.0);
+    assert!(joint_state.velocity().is_none());
+    assert!(joint_state.acceleration().is_none());
+    assert!(joint_state.jerk().is_none());
 }

--- a/src/hardware/sensor_interface.rs
+++ b/src/hardware/sensor_interface.rs
@@ -10,13 +10,13 @@ use super::joint_state::{JointState, JointStateRange};
 pub trait HardwareSensor {
     /// Returns the [Receiver] that is used to receive the current [JointState]
     /// and the currently available minimum and maximum rate of change.
-    fn get_current_state_receiver(&self) -> Result<Receiver<JointState>, Error>;
+    fn current_state_receiver(&self) -> Result<Receiver<JointState>, Error>;
 
     /// Returns the [NumberSpaceType] that is used to describe the motion of the joint.
-    fn get_joint_motion_type(&self) -> NumberSpaceType;
+    fn joint_motion_type(&self) -> NumberSpaceType;
 
     /// Returns the minimum and maximum states for the actuator.
-    fn get_joint_range(&self) -> JointStateRange;
+    fn joint_range(&self) -> JointStateRange;
 
     /// Stores the notification function for updating the software actuator
     /// and the [ChangeID] that informs the software actuator which hardware

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,17 +73,17 @@
 //! }
 //!
 //! impl HardwareActuator for MockHardwareActuator {
-//!     fn get_actuator_motion_type(&self) -> NumberSpaceType {
+//!     fn actuator_motion_type(&self) -> NumberSpaceType {
 //!         NumberSpaceType::LinearUnlimited
 //!     }
 //!
-//!     fn get_current_state_receiver(
+//!     fn current_state_receiver(
 //!         &self,
 //!     ) -> Result<Receiver<(JointState, ActuatorAvailableRatesOfChange)>, Error> {
 //!         Ok(self.receiver.clone())
 //!     }
 //!
-//!     fn get_command_sender(&self) -> Result<Sender<JointState>, Error> {
+//!     fn command_sender(&self) -> Result<Sender<JointState>, Error> {
 //!         Ok(self.command_sender.clone())
 //!     }
 //!
@@ -92,7 +92,7 @@
 //!         self.update_sender = Some(sender);
 //!     }
 //!
-//!     fn get_actuator_range(&self) -> JointStateRange {
+//!     fn actuator_range(&self) -> JointStateRange {
 //!         todo!()
 //!     }
 //! }
@@ -320,15 +320,15 @@
 //! }
 //!
 //! impl HardwareSensor for MySensor {
-//!     fn get_current_state_receiver(&self) -> Result<Receiver<JointState>, Error> {
+//!     fn current_state_receiver(&self) -> Result<Receiver<JointState>, Error> {
 //!         Ok(self.receiver.clone())
 //!     }
 //!
-//!     fn get_joint_motion_type(&self) -> NumberSpaceType {
+//!     fn joint_motion_type(&self) -> NumberSpaceType {
 //!          NumberSpaceType::LinearUnlimited
 //!     }
 //!
-//!     fn get_joint_range(&self) -> JointStateRange {
+//!     fn joint_range(&self) -> JointStateRange {
 //!         // This could be a constant value, or a value depending on the current position
 //!         // of the joint
 //!         let minimum = JointState::new(
@@ -428,11 +428,11 @@
 //! }
 //!
 //! impl HardwareActuator for MyActuator {
-//!     fn get_actuator_motion_type(&self) -> NumberSpaceType {
+//!     fn actuator_motion_type(&self) -> NumberSpaceType {
 //!          NumberSpaceType::LinearUnlimited
 //!     }
 //!
-//!     fn get_actuator_range(&self) -> JointStateRange {
+//!     fn actuator_range(&self) -> JointStateRange {
 //!         // This could be a constant value, or a value depending on the current position
 //!         // of the joint
 //!         let minimum = JointState::new(
@@ -451,11 +451,11 @@
 //!         JointStateRange::new(minimum, maximum)
 //!     }
 //!
-//!     fn get_command_sender(&self) -> Result<Sender<JointState>, Error> {
+//!     fn command_sender(&self) -> Result<Sender<JointState>, Error> {
 //!         Ok(self.command_sender.clone())
 //!     }
 //!
-//!     fn get_current_state_receiver(&self) -> Result<Receiver<(JointState, ActuatorAvailableRatesOfChange)>, Error> {
+//!     fn current_state_receiver(&self) -> Result<Receiver<(JointState, ActuatorAvailableRatesOfChange)>, Error> {
 //!         Ok(self.receiver.clone())
 //!     }
 //!

--- a/src/model_elements.rs
+++ b/src/model_elements.rs
@@ -70,17 +70,17 @@
 //! }
 //!
 //! impl HardwareActuator for MockHardwareActuator {
-//!     fn get_actuator_motion_type(&self) -> NumberSpaceType {
+//!     fn actuator_motion_type(&self) -> NumberSpaceType {
 //!         NumberSpaceType::LinearUnlimited
 //!     }
 //!
-//!     fn get_current_state_receiver(
+//!     fn current_state_receiver(
 //!         &self,
 //!     ) -> Result<Receiver<(JointState, ActuatorAvailableRatesOfChange)>, Error> {
 //!         Ok(self.receiver.clone())
 //!     }
 //!
-//!     fn get_command_sender(&self) -> Result<Sender<JointState>, Error> {
+//!     fn command_sender(&self) -> Result<Sender<JointState>, Error> {
 //!         Ok(self.command_sender.clone())
 //!     }
 //!
@@ -89,7 +89,7 @@
 //!         self.update_sender = Some(sender);
 //!     }
 //!
-//!     fn get_actuator_range(&self) -> JointStateRange {
+//!     fn actuator_range(&self) -> JointStateRange {
 //!         todo!()
 //!     }
 //! }

--- a/src/model_elements/frame_elements_tests.rs
+++ b/src/model_elements/frame_elements_tests.rs
@@ -134,11 +134,11 @@ struct MockHardwareSensor {
 }
 
 impl HardwareSensor for MockHardwareSensor {
-    fn get_joint_motion_type(&self) -> NumberSpaceType {
+    fn joint_motion_type(&self) -> NumberSpaceType {
         NumberSpaceType::LinearUnlimited
     }
 
-    fn get_current_state_receiver(&self) -> Result<Receiver<JointState>, Error> {
+    fn current_state_receiver(&self) -> Result<Receiver<JointState>, Error> {
         Ok(self.receiver.clone())
     }
 
@@ -147,7 +147,7 @@ impl HardwareSensor for MockHardwareSensor {
         self.update_sender = Some(sender);
     }
 
-    fn get_joint_range(&self) -> crate::hardware::joint_state::JointStateRange {
+    fn joint_range(&self) -> crate::hardware::joint_state::JointStateRange {
         todo!()
     }
 }
@@ -161,17 +161,17 @@ struct MockHardwareActuator {
 }
 
 impl HardwareActuator for MockHardwareActuator {
-    fn get_actuator_motion_type(&self) -> NumberSpaceType {
+    fn actuator_motion_type(&self) -> NumberSpaceType {
         NumberSpaceType::LinearUnlimited
     }
 
-    fn get_current_state_receiver(
+    fn current_state_receiver(
         &self,
     ) -> Result<Receiver<(JointState, ActuatorAvailableRatesOfChange)>, Error> {
         Ok(self.receiver.clone())
     }
 
-    fn get_command_sender(&self) -> Result<Sender<JointState>, Error> {
+    fn command_sender(&self) -> Result<Sender<JointState>, Error> {
         Ok(self.command_sender.clone())
     }
 
@@ -180,7 +180,7 @@ impl HardwareActuator for MockHardwareActuator {
         self.update_sender = Some(sender);
     }
 
-    fn get_actuator_range(&self) -> crate::hardware::joint_state::JointStateRange {
+    fn actuator_range(&self) -> crate::hardware::joint_state::JointStateRange {
         todo!()
     }
 }
@@ -223,7 +223,7 @@ fn test_joint_sensor_get_value() {
     // Allow some time to ensure the task is not processed
     std::thread::sleep(Duration::from_millis(20));
 
-    let result = sensor.get_value();
+    let result = sensor.value();
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), state);
 }
@@ -274,7 +274,7 @@ fn test_actuator_get_value() {
     // Allow some time to ensure the task is not processed
     std::thread::sleep(Duration::from_millis(20));
 
-    let result = actuator.get_value();
+    let result = actuator.value();
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), state);
 }
@@ -294,7 +294,7 @@ fn test_actuator_set_value() {
 
     let actuator_instance = Actuator::new(&mut actuator, &change_processor).unwrap();
     let state = JointState::new(2.0, Some(2.0), Some(2.0), Some(2.0));
-    let result = actuator_instance.set_value(state.clone());
+    let result = actuator_instance.update_state(state.clone());
     assert!(result.is_ok());
 
     let cmd_result = cmd_receiver.recv();

--- a/src/model_elements/model_tests.rs
+++ b/src/model_elements/model_tests.rs
@@ -64,10 +64,10 @@ fn when_adding_an_single_element_with_no_parent_to_a_kinematic_tree_it_should_be
         };
     }
 
-    let element_ref = tree.get_element(&element_id).unwrap();
+    let element_ref = tree.element(&element_id).unwrap();
     assert_eq!(element_ref.name(), name);
 
-    let body_ref = tree.get_body_element().unwrap();
+    let body_ref = tree.body_element().unwrap();
 
     assert_eq!(body_ref.name(), name);
 }
@@ -124,7 +124,7 @@ fn when_adding_an_multiple_elements_to_a_kinematic_tree_it_should_only_have_one_
     }
 
     let imtree = &tree;
-    let coll = imtree.get_elements().collect::<Vec<&ReferenceFrame>>();
+    let coll = imtree.elements().collect::<Vec<&ReferenceFrame>>();
     assert_eq!(2, coll.len());
 
     assert!(coll.iter().any(|e| *e.id() == first_id));
@@ -247,14 +247,14 @@ fn when_adding_an_element_to_a_kinematic_tree_it_should_only_be_a_wheel_in_a_spe
     }
 
     let imtree = &tree;
-    let coll = imtree.get_elements().collect::<Vec<&ReferenceFrame>>();
+    let coll = imtree.elements().collect::<Vec<&ReferenceFrame>>();
     assert_eq!(3, coll.len());
 
     assert!(!imtree.is_wheel(&first_id).unwrap());
     assert!(!imtree.is_wheel(&second_id).unwrap());
     assert!(imtree.is_wheel(&third_id).unwrap());
 
-    let wheels: Vec<&ReferenceFrame> = imtree.get_wheels().unwrap().collect();
+    let wheels: Vec<&ReferenceFrame> = imtree.wheels().unwrap().collect();
 
     assert_eq!(1, wheels.len());
     assert_eq!(&third_id, wheels[0].id());
@@ -340,7 +340,7 @@ fn when_adding_a_child_to_an_element_in_a_kinematic_tree_it_should_not_be_a_whee
         assert!(!tree.is_wheel(&first_id).unwrap());
         assert!(tree.is_wheel(&second_id).unwrap());
 
-        let wheels = tree.get_wheels().unwrap();
+        let wheels = tree.wheels().unwrap();
         for elt in wheels {
             let id_ref = elt.id();
             if id_ref != &second_id {
@@ -370,7 +370,7 @@ fn when_adding_a_child_to_an_element_in_a_kinematic_tree_it_should_not_be_a_whee
         assert!(!tree.is_wheel(&second_id).unwrap());
         assert!(tree.is_wheel(&third_id).unwrap());
 
-        let wheels = tree.get_wheels().unwrap();
+        let wheels = tree.wheels().unwrap();
         for elt in wheels {
             let id_ref = elt.id();
             if id_ref != &third_id {
@@ -548,7 +548,7 @@ fn when_adding_leaf_elements_to_a_kinematic_tree_it_should_be_multiple_wheels() 
     }
 
     let imtree = &tree;
-    let coll = imtree.get_elements().collect::<Vec<&ReferenceFrame>>();
+    let coll = imtree.elements().collect::<Vec<&ReferenceFrame>>();
     assert_eq!(5, coll.len());
 
     assert!(!imtree.is_wheel(&body_id).unwrap());
@@ -557,7 +557,7 @@ fn when_adding_leaf_elements_to_a_kinematic_tree_it_should_be_multiple_wheels() 
     assert!(imtree.is_wheel(&third_wheel_id).unwrap());
     assert!(imtree.is_wheel(&fourth_wheel_id).unwrap());
 
-    let wheels: Vec<&ReferenceFrame> = imtree.get_wheels().unwrap().collect();
+    let wheels: Vec<&ReferenceFrame> = imtree.wheels().unwrap().collect();
 
     assert_eq!(4, wheels.len());
     assert_eq!(4, imtree.number_of_wheels());
@@ -566,7 +566,7 @@ fn when_adding_leaf_elements_to_a_kinematic_tree_it_should_be_multiple_wheels() 
 #[test]
 fn when_getting_the_body_with_no_frame_elements_it_should_error() {
     let tree = KinematicTree::new();
-    match tree.get_body_element() {
+    match tree.body_element() {
         Ok(_) => assert!(
             false,
             "Retrieved a body element when no elements were present in the tree."
@@ -653,7 +653,7 @@ fn when_getting_the_children_it_should_return_all_the_directly_connected_element
         };
     }
 
-    match tree.get_children(&first_id) {
+    match tree.children_of(&first_id) {
         Err(e) => assert!(
             false,
             "Got an error retrieving the children, but should not have. Error: {}.",
@@ -743,7 +743,7 @@ fn when_getting_the_children_with_invalid_parent_it_should_error() {
         };
     }
 
-    match tree.get_children(&second_id) {
+    match tree.children_of(&second_id) {
         Err(_) => assert!(false),
         Ok(mut i) => {
             assert!(!i.any(|_e| true));
@@ -825,7 +825,7 @@ fn when_getting_the_children_with_no_parent_it_should_error() {
         };
     }
 
-    match tree.get_children(&FrameID::none()) {
+    match tree.children_of(&FrameID::none()) {
         Err(e) => assert!(
             e == Error::InvalidFrameID {
                 id: FrameID::none()
@@ -917,7 +917,7 @@ fn when_getting_the_parent_it_should_return_the_correct_element() {
     }
 
     let imtree = &tree;
-    match imtree.get_parent(&second_id) {
+    match imtree.parent_of(&second_id) {
         Err(e) => assert!(
             false,
             "Got an error retrieving the children, but should not have. Error was: {}",
@@ -928,7 +928,7 @@ fn when_getting_the_parent_it_should_return_the_correct_element() {
         }
     };
 
-    match imtree.get_parent(&third_id) {
+    match imtree.parent_of(&third_id) {
         Err(e) => assert!(
             false,
             "Got an error retrieving the children, but should not have. Error was: {}",
@@ -1015,7 +1015,7 @@ fn when_getting_the_parent_with_invalid_frame_elements_it_should_error() {
 
     let imtree = &tree;
     let unknown_id = FrameID::new();
-    match imtree.get_parent(&unknown_id) {
+    match imtree.parent_of(&unknown_id) {
         Err(e) => assert_eq!(e, Error::InvalidFrameID { id: unknown_id }),
         Ok(_) => assert!(
             false,
@@ -1028,7 +1028,7 @@ fn when_getting_the_parent_with_invalid_frame_elements_it_should_error() {
 fn when_getting_the_parent_with_no_frame_elements_it_should_error() {
     let tree = KinematicTree::new();
     let child_id = FrameID::new();
-    match tree.get_parent(&child_id) {
+    match tree.parent_of(&child_id) {
         Ok(_) => assert!(
             false,
             "Expected the test to produce an error, but it didn't."
@@ -1040,7 +1040,7 @@ fn when_getting_the_parent_with_no_frame_elements_it_should_error() {
 #[test]
 fn when_getting_the_wheels_with_no_frame_elements_it_should_error() {
     let tree = KinematicTree::new();
-    match tree.get_wheels() {
+    match tree.wheels() {
         Ok(_) => assert!(
             false,
             "Expected the test to produce an error, but it didn't."
@@ -1150,17 +1150,17 @@ struct MockHardwareActuator {
 }
 
 impl HardwareActuator for MockHardwareActuator {
-    fn get_actuator_motion_type(&self) -> NumberSpaceType {
+    fn actuator_motion_type(&self) -> NumberSpaceType {
         NumberSpaceType::LinearUnlimited
     }
 
-    fn get_current_state_receiver(
+    fn current_state_receiver(
         &self,
     ) -> Result<Receiver<(JointState, ActuatorAvailableRatesOfChange)>, Error> {
         Ok(self.receiver.clone())
     }
 
-    fn get_command_sender(&self) -> Result<Sender<JointState>, Error> {
+    fn command_sender(&self) -> Result<Sender<JointState>, Error> {
         Ok(self.command_sender.clone())
     }
 
@@ -1169,7 +1169,7 @@ impl HardwareActuator for MockHardwareActuator {
         self.update_sender = Some(sender);
     }
 
-    fn get_actuator_range(&self) -> crate::hardware::joint_state::JointStateRange {
+    fn actuator_range(&self) -> crate::hardware::joint_state::JointStateRange {
         todo!()
     }
 }
@@ -1393,13 +1393,13 @@ fn when_adding_actuated_chassis_element_it_should_store_the_element() {
     let frame_id = result.unwrap();
     assert!(!frame_id.is_none());
 
-    let degree_of_freedom_result = model.get_frame_degree_of_freedom(&frame_id);
+    let degree_of_freedom_result = model.frame_degree_of_freedom(&frame_id);
     assert!(degree_of_freedom_result.is_ok());
 
     let dof = degree_of_freedom_result.unwrap();
     assert_eq!(FrameDofType::PrismaticX, dof);
 
-    let frame_result = model.get_reference_frame(&frame_id);
+    let frame_result = model.reference_frame(&frame_id);
     assert!(frame_result.is_ok());
 
     let frame = frame_result.unwrap();
@@ -1407,13 +1407,13 @@ fn when_adding_actuated_chassis_element_it_should_store_the_element() {
     assert!(frame.is_actuated());
     assert!(model.is_actuated(&frame_id));
 
-    let chassis_result = model.get_chassis_element(&frame_id);
+    let chassis_result = model.chassis_element(&frame_id);
     assert!(chassis_result.is_ok());
 
     let chassis = chassis_result.unwrap();
     assert_eq!(name, chassis.name());
 
-    let actuator_result = model.get_actuator(&frame_id);
+    let actuator_result = model.actuator_for(&frame_id);
     assert!(actuator_result.is_ok());
 }
 
@@ -1620,19 +1620,19 @@ fn when_adding_body_it_should_store_the_element() {
     let body_id = result.unwrap();
     assert!(!body_id.is_none());
 
-    let body_result = model.get_body();
+    let body_result = model.body();
     assert!(body_result.is_ok());
 
     let id = body_result.unwrap();
     assert_eq!(body_id, *id);
 
-    let degree_of_freedom_result = model.get_frame_degree_of_freedom(id);
+    let degree_of_freedom_result = model.frame_degree_of_freedom(id);
     assert!(degree_of_freedom_result.is_ok());
 
     let dof = degree_of_freedom_result.unwrap();
     assert_eq!(FrameDofType::Static, dof);
 
-    let frame_result = model.get_reference_frame(id);
+    let frame_result = model.reference_frame(id);
     assert!(frame_result.is_ok());
 
     let frame = frame_result.unwrap();
@@ -1640,7 +1640,7 @@ fn when_adding_body_it_should_store_the_element() {
     assert!(!frame.is_actuated());
     assert!(!model.is_actuated(id));
 
-    let chassis_result = model.get_chassis_element(id);
+    let chassis_result = model.chassis_element(id);
     assert!(chassis_result.is_ok());
 
     let chassis = chassis_result.unwrap();
@@ -1691,13 +1691,13 @@ fn when_adding_static_chassis_element_it_should_store_the_element() {
     let frame_id = result.unwrap();
     assert!(!frame_id.is_none());
 
-    let degree_of_freedom_result = model.get_frame_degree_of_freedom(&frame_id);
+    let degree_of_freedom_result = model.frame_degree_of_freedom(&frame_id);
     assert!(degree_of_freedom_result.is_ok());
 
     let dof = degree_of_freedom_result.unwrap();
     assert_eq!(FrameDofType::Static, dof);
 
-    let frame_result = model.get_reference_frame(&frame_id);
+    let frame_result = model.reference_frame(&frame_id);
     assert!(frame_result.is_ok());
 
     let frame = frame_result.unwrap();
@@ -1705,7 +1705,7 @@ fn when_adding_static_chassis_element_it_should_store_the_element() {
     assert!(!frame.is_actuated());
     assert!(!model.is_actuated(&frame_id));
 
-    let chassis_result = model.get_chassis_element(&frame_id);
+    let chassis_result = model.chassis_element(&frame_id);
     assert!(chassis_result.is_ok());
 
     let chassis = chassis_result.unwrap();
@@ -1888,13 +1888,13 @@ fn when_adding_steering_element_it_should_store_the_element() {
     let frame_id = result.unwrap();
     assert!(!frame_id.is_none());
 
-    let degree_of_freedom_result = model.get_frame_degree_of_freedom(&frame_id);
+    let degree_of_freedom_result = model.frame_degree_of_freedom(&frame_id);
     assert!(degree_of_freedom_result.is_ok());
 
     let dof = degree_of_freedom_result.unwrap();
     assert_eq!(FrameDofType::RevoluteZ, dof);
 
-    let frame_result = model.get_reference_frame(&frame_id);
+    let frame_result = model.reference_frame(&frame_id);
     assert!(frame_result.is_ok());
 
     let frame = frame_result.unwrap();
@@ -1902,7 +1902,7 @@ fn when_adding_steering_element_it_should_store_the_element() {
     assert!(frame.is_actuated());
     assert!(model.is_actuated(&frame_id));
 
-    let chassis_result = model.get_chassis_element(&frame_id);
+    let chassis_result = model.chassis_element(&frame_id);
     assert!(chassis_result.is_ok());
 
     let chassis = chassis_result.unwrap();
@@ -2182,13 +2182,13 @@ fn when_adding_suspension_element_it_should_store_the_element() {
     let frame_id = result.unwrap();
     assert!(!frame_id.is_none());
 
-    let degree_of_freedom_result = model.get_frame_degree_of_freedom(&frame_id);
+    let degree_of_freedom_result = model.frame_degree_of_freedom(&frame_id);
     assert!(degree_of_freedom_result.is_ok());
 
     let dof = degree_of_freedom_result.unwrap();
     assert_eq!(FrameDofType::PrismaticX, dof);
 
-    let frame_result = model.get_reference_frame(&frame_id);
+    let frame_result = model.reference_frame(&frame_id);
     assert!(frame_result.is_ok());
 
     let frame = frame_result.unwrap();
@@ -2198,7 +2198,7 @@ fn when_adding_suspension_element_it_should_store_the_element() {
 
     assert_eq!(1, model.number_of_joint_constraints());
 
-    let chassis_result = model.get_chassis_element(&frame_id);
+    let chassis_result = model.chassis_element(&frame_id);
     assert!(chassis_result.is_ok());
 
     let chassis = chassis_result.unwrap();
@@ -2267,13 +2267,13 @@ fn when_adding_suspension_elements_multiple_times_it_should_store_the_elements()
     let frame_id1 = result1.unwrap();
     assert!(!frame_id1.is_none());
 
-    let degree_of_freedom_result1 = model.get_frame_degree_of_freedom(&frame_id1);
+    let degree_of_freedom_result1 = model.frame_degree_of_freedom(&frame_id1);
     assert!(degree_of_freedom_result1.is_ok());
 
     let dof1 = degree_of_freedom_result1.unwrap();
     assert_eq!(FrameDofType::PrismaticX, dof1);
 
-    let frame_result1 = model.get_reference_frame(&frame_id1);
+    let frame_result1 = model.reference_frame(&frame_id1);
     assert!(frame_result1.is_ok());
 
     let frame1 = frame_result1.unwrap();
@@ -2281,7 +2281,7 @@ fn when_adding_suspension_elements_multiple_times_it_should_store_the_elements()
     assert!(!frame1.is_actuated());
     assert!(!model.is_actuated(&frame_id1));
 
-    let chassis_result1 = model.get_chassis_element(&frame_id1);
+    let chassis_result1 = model.chassis_element(&frame_id1);
     assert!(chassis_result1.is_ok());
 
     let chassis1 = chassis_result1.unwrap();
@@ -2292,13 +2292,13 @@ fn when_adding_suspension_elements_multiple_times_it_should_store_the_elements()
     let frame_id2 = result2.unwrap();
     assert!(!frame_id2.is_none());
 
-    let degree_of_freedom_result2 = model.get_frame_degree_of_freedom(&frame_id2);
+    let degree_of_freedom_result2 = model.frame_degree_of_freedom(&frame_id2);
     assert!(degree_of_freedom_result2.is_ok());
 
     let dof2 = degree_of_freedom_result2.unwrap();
     assert_eq!(FrameDofType::PrismaticX, dof2);
 
-    let frame_result2 = model.get_reference_frame(&frame_id2);
+    let frame_result2 = model.reference_frame(&frame_id2);
     assert!(frame_result2.is_ok());
 
     let frame2 = frame_result2.unwrap();
@@ -2306,7 +2306,7 @@ fn when_adding_suspension_elements_multiple_times_it_should_store_the_elements()
     assert!(!frame2.is_actuated());
     assert!(!model.is_actuated(&frame_id2));
 
-    let chassis_result2 = model.get_chassis_element(&frame_id2);
+    let chassis_result2 = model.chassis_element(&frame_id2);
     assert!(chassis_result2.is_ok());
 
     let chassis2 = chassis_result2.unwrap();
@@ -2524,13 +2524,13 @@ fn when_adding_wheel_element_it_should_store_the_element() {
     let frame_id = result.unwrap();
     assert!(!frame_id.is_none());
 
-    let degree_of_freedom_result = model.get_frame_degree_of_freedom(&frame_id);
+    let degree_of_freedom_result = model.frame_degree_of_freedom(&frame_id);
     assert!(degree_of_freedom_result.is_ok());
 
     let dof = degree_of_freedom_result.unwrap();
     assert_eq!(FrameDofType::RevoluteY, dof);
 
-    let frame_result = model.get_reference_frame(&frame_id);
+    let frame_result = model.reference_frame(&frame_id);
     assert!(frame_result.is_ok());
 
     let frame = frame_result.unwrap();
@@ -2538,20 +2538,20 @@ fn when_adding_wheel_element_it_should_store_the_element() {
     assert!(frame.is_actuated());
     assert!(model.is_actuated(&frame_id));
 
-    let chassis_result = model.get_chassis_element(&frame_id);
+    let chassis_result = model.chassis_element(&frame_id);
     assert!(chassis_result.is_ok());
 
     let chassis = chassis_result.unwrap();
     assert_eq!(name, chassis.name());
 
-    let wheels_results = model.get_wheels();
+    let wheels_results = model.wheels();
     assert!(wheels_results.is_ok());
 
     let wheels = wheels_results.unwrap();
     assert!(wheels.len() == 1);
     assert_eq!(frame_id, *wheels[0]);
 
-    let steering_result = model.get_steering_frame_for_wheel(&frame_id);
+    let steering_result = model.steering_frame_for_wheel(&frame_id);
     assert!(steering_result.is_ok());
 
     let steering_from_wheel = steering_result.unwrap();
@@ -3020,7 +3020,7 @@ fn when_getting_actuator_with_non_existing_element_it_should_error() {
     let model = MotionModel::new();
 
     let non_existing_id = FrameID::new();
-    let actuator_result = model.get_actuator(&non_existing_id);
+    let actuator_result = model.actuator_for(&non_existing_id);
     assert!(actuator_result.is_err());
 }
 
@@ -3028,7 +3028,7 @@ fn when_getting_actuator_with_non_existing_element_it_should_error() {
 fn when_getting_body_without_elements_it_should_error() {
     let model = MotionModel::new();
 
-    let result = model.get_body();
+    let result = model.body();
     assert!(result.is_err());
 }
 
@@ -3037,7 +3037,7 @@ fn when_getting_chassis_element_with_non_existing_element_it_should_error() {
     let model = MotionModel::new();
 
     let non_existing_id = FrameID::new();
-    let actuator_result = model.get_chassis_element(&non_existing_id);
+    let actuator_result = model.chassis_element(&non_existing_id);
     assert!(actuator_result.is_err());
 }
 
@@ -3126,7 +3126,7 @@ fn when_getting_children_it_should_return_the_children() {
     let wheel_count = model.number_of_wheels();
     assert_eq!(2, wheel_count);
 
-    let result = model.get_children(&body_id);
+    let result = model.children_of(&body_id);
     assert!(result.is_ok());
 
     let children = result.unwrap();
@@ -3143,7 +3143,7 @@ fn when_getting_children_with_invalid_parent_it_should_error() {
     let _ = add_suspension_to_model(&mut model, &body_id, DriveModulePosition::LeftFront).unwrap();
 
     let invalid_id = FrameID::new();
-    let result = model.get_children(&invalid_id);
+    let result = model.children_of(&invalid_id);
 
     assert!(result.is_err());
 }
@@ -3154,7 +3154,7 @@ fn when_getting_frame_degree_of_freedom_with_invalid_frame_it_should_error() {
     let _ = add_body_to_model(&mut model).unwrap();
 
     let invalid_id = FrameID::new();
-    let result = model.get_frame_degree_of_freedom(&invalid_id);
+    let result = model.frame_degree_of_freedom(&invalid_id);
 
     assert!(result.is_err());
 }
@@ -3233,7 +3233,7 @@ fn when_getting_homogeneous_transform_to_body_with_one_element_and_motion_it_sho
     // Allow some time to ensure the task is not processed
     std::thread::sleep(Duration::from_millis(20));
 
-    let actuator_to_body = model.get_homogeneous_transform_to_body(&id);
+    let actuator_to_body = model.homogeneous_transform_to_body(&id);
     assert!(actuator_to_body.is_ok());
 
     let actuator_to_body_matrix = actuator_to_body.unwrap();
@@ -3292,7 +3292,7 @@ fn when_getting_homogeneous_transform_to_body_with_one_element_and_motion_it_sho
     // Allow some time to ensure the task is not processed
     std::thread::sleep(Duration::from_millis(20));
 
-    let actuator_to_body = model.get_homogeneous_transform_to_body(&id);
+    let actuator_to_body = model.homogeneous_transform_to_body(&id);
     assert!(actuator_to_body.is_ok());
 
     let actuator_to_body_matrix = actuator_to_body.unwrap();
@@ -3348,7 +3348,7 @@ fn when_getting_homogeneous_transform_to_body_with_one_element_and_no_motion_it_
 
     let expected = homogenous_suspension_to_body;
 
-    let suspension_to_body = model.get_homogeneous_transform_to_body(&suspension_id_leg1);
+    let suspension_to_body = model.homogeneous_transform_to_body(&suspension_id_leg1);
     assert!(suspension_to_body.is_ok());
 
     let wheel_to_body_matrix = suspension_to_body.unwrap();
@@ -3429,7 +3429,7 @@ fn when_getting_homogeneous_transform_to_body_with_multiple_elements_and_no_moti
 
     let expected = joint_1_to_body_matrix * joint_2_to_joint_1_matrix;
 
-    let joint_2_to_body = model.get_homogeneous_transform_to_body(&id_joint_2);
+    let joint_2_to_body = model.homogeneous_transform_to_body(&id_joint_2);
     assert!(joint_2_to_body.is_ok());
     let joint_2_to_body_matrix = joint_2_to_body.unwrap();
 
@@ -3578,7 +3578,7 @@ fn when_getting_homogeneous_transform_to_body_with_primatic_x_and_prismatic_y_mo
     // Allow some time to ensure the task is not processed
     std::thread::sleep(Duration::from_millis(20));
 
-    let joint_2_to_body = model.get_homogeneous_transform_to_body(&id_joint_2);
+    let joint_2_to_body = model.homogeneous_transform_to_body(&id_joint_2);
     assert!(joint_2_to_body.is_ok());
     let joint_2_to_body_matrix = joint_2_to_body.unwrap();
 
@@ -3731,7 +3731,7 @@ fn when_getting_homogeneous_transform_to_body_with_primatic_x_and_prismatic_z_mo
     // Allow some time to ensure the task is not processed
     std::thread::sleep(Duration::from_millis(20));
 
-    let joint_2_to_body = model.get_homogeneous_transform_to_body(&id_joint_2);
+    let joint_2_to_body = model.homogeneous_transform_to_body(&id_joint_2);
     assert!(joint_2_to_body.is_ok());
     let joint_2_to_body_matrix = joint_2_to_body.unwrap();
 
@@ -3884,7 +3884,7 @@ fn when_getting_homogeneous_transform_to_body_with_primatic_y_and_prismatic_z_mo
     // Allow some time to ensure the task is not processed
     std::thread::sleep(Duration::from_millis(20));
 
-    let joint_2_to_body = model.get_homogeneous_transform_to_body(&id_joint_2);
+    let joint_2_to_body = model.homogeneous_transform_to_body(&id_joint_2);
     assert!(joint_2_to_body.is_ok());
     let joint_2_to_body_matrix = joint_2_to_body.unwrap();
 
@@ -4047,8 +4047,7 @@ fn when_getting_homogeneous_transform_to_frame_across_wheel_chains_and_motion_it
     // Allow some time to ensure the task is not processed
     std::thread::sleep(Duration::from_millis(20));
 
-    let joint_2_to_joint_1 =
-        model.get_homogeneous_transform_between_frames(&id_joint_2, &id_joint_1);
+    let joint_2_to_joint_1 = model.homogeneous_transform_between_frames(&id_joint_2, &id_joint_1);
     assert!(joint_2_to_joint_1.is_ok());
     let joint_2_to_joint_1_matrix = joint_2_to_joint_1.unwrap();
 
@@ -4125,8 +4124,7 @@ fn when_getting_homogeneous_transform_to_frame_across_wheel_chains_and_no_motion
     )
     .unwrap();
 
-    let joint_2_to_joint_1 =
-        model.get_homogeneous_transform_between_frames(&id_joint_2, &id_joint_1);
+    let joint_2_to_joint_1 = model.homogeneous_transform_between_frames(&id_joint_2, &id_joint_1);
     assert!(joint_2_to_joint_1.is_ok());
 
     let joint_2_to_joint_1_matrix = joint_2_to_joint_1.unwrap();
@@ -4231,7 +4229,7 @@ fn when_getting_homogeneous_transform_to_parent_with_no_motion_it_should_return_
     let wheel_id_leg1 = add_wheel_to_model(&mut model, &steering_id_leg1, wheel_actuator).unwrap();
 
     // wheel to steering
-    let wheel_to_steering = model.get_homogeneous_transform_to_parent(&wheel_id_leg1);
+    let wheel_to_steering = model.homogeneous_transform_to_parent(&wheel_id_leg1);
     assert!(wheel_to_steering.is_ok());
 
     let wheel_to_steering_matrix = wheel_to_steering.unwrap();
@@ -4249,7 +4247,7 @@ fn when_getting_homogeneous_transform_to_parent_with_no_motion_it_should_return_
     assert_eq!(expected, wheel_to_steering_matrix);
 
     // steering to suspension
-    let steering_to_suspension = model.get_homogeneous_transform_to_parent(&steering_id_leg1);
+    let steering_to_suspension = model.homogeneous_transform_to_parent(&steering_id_leg1);
     assert!(steering_to_suspension.is_ok());
 
     let steering_to_suspension_matrix = steering_to_suspension.unwrap();
@@ -4271,7 +4269,7 @@ fn when_getting_homogeneous_transform_to_parent_with_no_motion_it_should_return_
     assert_eq!(expected, steering_to_suspension_matrix);
 
     // suspension to body
-    let suspension_to_body = model.get_homogeneous_transform_to_parent(&suspension_id_leg1);
+    let suspension_to_body = model.homogeneous_transform_to_parent(&suspension_id_leg1);
     assert!(suspension_to_body.is_ok());
 
     let suspension_to_body_matrix = suspension_to_body.unwrap();
@@ -4321,7 +4319,7 @@ fn when_getting_homogeneous_transform_to_parent_with_primatic_x_motion_should_re
     .unwrap();
 
     // wheel to steering
-    let actuator_to_body = model.get_homogeneous_transform_to_parent(&id);
+    let actuator_to_body = model.homogeneous_transform_to_parent(&id);
     assert!(actuator_to_body.is_ok());
 
     let actuator_to_body_matrix = actuator_to_body.unwrap();
@@ -4358,7 +4356,7 @@ fn when_getting_homogeneous_transform_to_parent_with_primatic_x_motion_should_re
     // Allow some time to ensure the task is not processed
     std::thread::sleep(Duration::from_millis(20));
 
-    let actuator_to_body = model.get_homogeneous_transform_to_parent(&id);
+    let actuator_to_body = model.homogeneous_transform_to_parent(&id);
     assert!(actuator_to_body.is_ok());
 
     let actuator_to_body_matrix = actuator_to_body.unwrap();
@@ -4395,7 +4393,7 @@ fn when_getting_homogeneous_transform_to_parent_with_primatic_x_motion_should_re
     // Allow some time to ensure the task is not processed
     std::thread::sleep(Duration::from_millis(20));
 
-    let actuator_to_body = model.get_homogeneous_transform_to_parent(&id);
+    let actuator_to_body = model.homogeneous_transform_to_parent(&id);
     assert!(actuator_to_body.is_ok());
 
     let actuator_to_body_matrix = actuator_to_body.unwrap();
@@ -4445,7 +4443,7 @@ fn when_getting_homogeneous_transform_to_parent_with_primatic_y_motion_should_re
     .unwrap();
 
     // wheel to steering
-    let actuator_to_body = model.get_homogeneous_transform_to_parent(&id);
+    let actuator_to_body = model.homogeneous_transform_to_parent(&id);
     assert!(actuator_to_body.is_ok());
 
     let actuator_to_body_matrix = actuator_to_body.unwrap();
@@ -4482,7 +4480,7 @@ fn when_getting_homogeneous_transform_to_parent_with_primatic_y_motion_should_re
     // Allow some time to ensure the task is not processed
     std::thread::sleep(Duration::from_millis(20));
 
-    let actuator_to_body = model.get_homogeneous_transform_to_parent(&id);
+    let actuator_to_body = model.homogeneous_transform_to_parent(&id);
     assert!(actuator_to_body.is_ok());
 
     let actuator_to_body_matrix = actuator_to_body.unwrap();
@@ -4519,7 +4517,7 @@ fn when_getting_homogeneous_transform_to_parent_with_primatic_y_motion_should_re
     // Allow some time to ensure the task is not processed
     std::thread::sleep(Duration::from_millis(20));
 
-    let actuator_to_body = model.get_homogeneous_transform_to_parent(&id);
+    let actuator_to_body = model.homogeneous_transform_to_parent(&id);
     assert!(actuator_to_body.is_ok());
 
     let actuator_to_body_matrix = actuator_to_body.unwrap();
@@ -4569,7 +4567,7 @@ fn when_getting_homogeneous_transform_to_parent_with_primatic_z_motion_should_re
     .unwrap();
 
     // wheel to steering
-    let actuator_to_body = model.get_homogeneous_transform_to_parent(&id);
+    let actuator_to_body = model.homogeneous_transform_to_parent(&id);
     assert!(actuator_to_body.is_ok());
 
     let actuator_to_body_matrix = actuator_to_body.unwrap();
@@ -4606,7 +4604,7 @@ fn when_getting_homogeneous_transform_to_parent_with_primatic_z_motion_should_re
     // Allow some time to ensure the task is not processed
     std::thread::sleep(Duration::from_millis(20));
 
-    let actuator_to_body = model.get_homogeneous_transform_to_parent(&id);
+    let actuator_to_body = model.homogeneous_transform_to_parent(&id);
     assert!(actuator_to_body.is_ok());
 
     let actuator_to_body_matrix = actuator_to_body.unwrap();
@@ -4643,7 +4641,7 @@ fn when_getting_homogeneous_transform_to_parent_with_primatic_z_motion_should_re
     // Allow some time to ensure the task is not processed
     std::thread::sleep(Duration::from_millis(20));
 
-    let actuator_to_body = model.get_homogeneous_transform_to_parent(&id);
+    let actuator_to_body = model.homogeneous_transform_to_parent(&id);
     assert!(actuator_to_body.is_ok());
 
     let actuator_to_body_matrix = actuator_to_body.unwrap();
@@ -4693,7 +4691,7 @@ fn when_getting_homogeneous_transform_to_parent_with_revolute_x_motion_should_re
     .unwrap();
 
     // wheel to steering
-    let actuator_to_body = model.get_homogeneous_transform_to_parent(&id);
+    let actuator_to_body = model.homogeneous_transform_to_parent(&id);
     assert!(actuator_to_body.is_ok());
 
     let actuator_to_body_matrix = actuator_to_body.unwrap();
@@ -4733,7 +4731,7 @@ fn when_getting_homogeneous_transform_to_parent_with_revolute_x_motion_should_re
     // Allow some time to ensure the task is not processed
     std::thread::sleep(Duration::from_millis(20));
 
-    let actuator_to_body = model.get_homogeneous_transform_to_parent(&id);
+    let actuator_to_body = model.homogeneous_transform_to_parent(&id);
     assert!(actuator_to_body.is_ok());
 
     let actuator_to_body_matrix = actuator_to_body.unwrap();
@@ -4791,7 +4789,7 @@ fn when_getting_homogeneous_transform_to_parent_with_revolute_x_motion_should_re
     // Allow some time to ensure the task is not processed
     std::thread::sleep(Duration::from_millis(20));
 
-    let actuator_to_body = model.get_homogeneous_transform_to_parent(&id);
+    let actuator_to_body = model.homogeneous_transform_to_parent(&id);
     assert!(actuator_to_body.is_ok());
 
     let actuator_to_body_matrix = actuator_to_body.unwrap();
@@ -4861,7 +4859,7 @@ fn when_getting_homogeneous_transform_to_parent_with_revolute_y_motion_should_re
     .unwrap();
 
     // wheel to steering
-    let actuator_to_body = model.get_homogeneous_transform_to_parent(&id);
+    let actuator_to_body = model.homogeneous_transform_to_parent(&id);
     assert!(actuator_to_body.is_ok());
 
     let actuator_to_body_matrix = actuator_to_body.unwrap();
@@ -4900,7 +4898,7 @@ fn when_getting_homogeneous_transform_to_parent_with_revolute_y_motion_should_re
     // Allow some time to ensure the task is not processed
     std::thread::sleep(Duration::from_millis(20));
 
-    let actuator_to_body = model.get_homogeneous_transform_to_parent(&id);
+    let actuator_to_body = model.homogeneous_transform_to_parent(&id);
     assert!(actuator_to_body.is_ok());
 
     let actuator_to_body_matrix = actuator_to_body.unwrap();
@@ -4959,7 +4957,7 @@ fn when_getting_homogeneous_transform_to_parent_with_revolute_y_motion_should_re
     // Allow some time to ensure the task is not processed
     std::thread::sleep(Duration::from_millis(20));
 
-    let actuator_to_body = model.get_homogeneous_transform_to_parent(&id);
+    let actuator_to_body = model.homogeneous_transform_to_parent(&id);
     assert!(actuator_to_body.is_ok());
 
     let actuator_to_body_matrix = actuator_to_body.unwrap();
@@ -5028,7 +5026,7 @@ fn when_getting_homogeneous_transform_to_parent_with_revolute_z_motion_should_re
     )
     .unwrap();
 
-    let actuator_to_body = model.get_homogeneous_transform_to_parent(&id);
+    let actuator_to_body = model.homogeneous_transform_to_parent(&id);
     assert!(actuator_to_body.is_ok());
 
     let actuator_to_body_matrix = actuator_to_body.unwrap();
@@ -5067,7 +5065,7 @@ fn when_getting_homogeneous_transform_to_parent_with_revolute_z_motion_should_re
     // Allow some time to ensure the task is not processed
     std::thread::sleep(Duration::from_millis(20));
 
-    let actuator_to_body = model.get_homogeneous_transform_to_parent(&id);
+    let actuator_to_body = model.homogeneous_transform_to_parent(&id);
     assert!(actuator_to_body.is_ok());
 
     let actuator_to_body_matrix = actuator_to_body.unwrap();
@@ -5122,7 +5120,7 @@ fn when_getting_homogeneous_transform_to_parent_with_revolute_z_motion_should_re
     // Allow some time to ensure the task is not processed
     std::thread::sleep(Duration::from_millis(20));
 
-    let actuator_to_body = model.get_homogeneous_transform_to_parent(&id);
+    let actuator_to_body = model.homogeneous_transform_to_parent(&id);
     assert!(actuator_to_body.is_ok());
 
     let actuator_to_body_matrix = actuator_to_body.unwrap();
@@ -5317,7 +5315,7 @@ fn when_getting_parent_with_invalid_frame_it_should_error() {
     let _ = add_body_to_model(&mut model).unwrap();
 
     let invalid_id = FrameID::new();
-    let result = model.get_parent(&invalid_id);
+    let result = model.parent_of(&invalid_id);
 
     assert!(result.is_err());
 }
@@ -5328,7 +5326,7 @@ fn when_getting_steering_frame_for_wheel_with_invalid_frame_it_should_error() {
     let _ = add_body_to_model(&mut model).unwrap();
 
     let invalid_id = FrameID::new();
-    let result = model.get_steering_frame_for_wheel(&invalid_id);
+    let result = model.steering_frame_for_wheel(&invalid_id);
 
     assert!(result.is_err());
 }


### PR DESCRIPTION
So that we align with the Rust naming guidelines

resolves #40