### PR TITLE
chore: Only update `install-action` once a month

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,16 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:best-practices"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "taiki-e/install-action"
+      ],
+      "groupName": "install-action",
+      "schedule": [
+        "on the first day of the month"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
Because there are so many updates and they cause a lot of PR noise.

references #58 but may not fix it. We'll need to watch the PRs for a bit.